### PR TITLE
fix: Add `--no-minify` option for Parcel

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "jest --coverage",
     "demo": "parcel demo/index.html",
     "build": "rm -rf ./dist && yarn rollup -c",
-    "build:demo": "rm -rf ./dist-demo && parcel build demo/index.html -d ./dist-demo --public-url .",
+    "build:demo": "rm -rf ./dist-demo && parcel build demo/index.html -d ./dist-demo --public-url . --no-minify",
     "prepublishOnly": "yarn build"
   },
   "devDependencies": {


### PR DESCRIPTION
- Without it, Parcel unexpectedly omits empty tag like `<path></path>`
- Tried to replace to Parcel2, but it didn't work for some reason