### PR TITLE
Fix invalid parsing for decimal shorthand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [3.0.8] - 2023-02-18
 ### Changed
 - Migrate `parcel-bundler` to `parcel2` for demo
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Migrate `parcel-bundler` to `parcel2` for demo
 
+### Fixed
+- Fix invalid parsing for decimal shorthand: `0.1.2` should be treated as `0.1 0.2`
+
 ## [3.0.7] - 2023-01-21
 ### Fixed
 - Fix unexpected error for parsing arc segment when its radius is close to 0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okageo",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "parse SVG to polygons",
   "main": "./dist/okageo.js",
   "module": "./dist/okageo.mjs",

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -1335,6 +1335,7 @@ export function splitD(dString: string): string[][] {
     .replace(/([^e])(-|\+)/g, '$1 $2')
     .split(/,| /)
     .filter((str) => str)
+    .flatMap(complementDecimalShorthand)
   // 直前のコマンド
   let pastCommand = 'M'
 
@@ -1402,6 +1403,16 @@ export function splitD(dString: string): string[][] {
   }
 
   return ret
+}
+
+/**
+ * '1.2.3' => ['1.2', '0.3']
+ */
+function complementDecimalShorthand(str: string): string[] {
+  const list = str.split(/\./)
+  return list.length <= 2
+    ? [str]
+    : [`${list[0]}.${list[1]}`, ...list.slice(2).map((v) => `0.${v}`)]
 }
 
 /**

--- a/test/svg.test.ts
+++ b/test/svg.test.ts
@@ -1010,6 +1010,13 @@ describe('splitD pathのd要素分解', () => {
         ['l', '-2.2e-14', '-125'],
         ['l', '124', '-125'],
       ])
+
+      // Decimal shorthand
+      const res3 = svg.splitD('M0.1 0.2 L0.5.8.1.2')
+      expect(res3).toHaveLength(3)
+      expect(res3[0]).toEqual(['M', '0.1', '0.2'])
+      expect(res3[1]).toEqual(['L', '0.5', '0.8'])
+      expect(res3[2]).toEqual(['L', '0.1', '0.2'])
     })
   })
 })


### PR DESCRIPTION
Fix invalid parsing for decimal shorthand: `0.1.2` should be treated as `0.1 0.2`